### PR TITLE
fix: use page counter instead of true page number

### DIFF
--- a/preview/glossy/0.2.1/src/gloss.typ
+++ b/preview/glossy/0.2.1/src/gloss.typ
@@ -281,7 +281,7 @@
     .map(l => locate(l))
     .map(loc => numbering(
       __default(loc.page-numbering(), "1"),
-      counter(page).at(loc)
+      ..counter(page).at(loc)
     ))
 
   // Create links, excluding duplicate page numbers

--- a/preview/glossy/0.2.1/src/gloss.typ
+++ b/preview/glossy/0.2.1/src/gloss.typ
@@ -281,7 +281,7 @@
     .map(l => locate(l))
     .map(loc => numbering(
       __default(loc.page-numbering(), "1"),
-      loc.page()
+      counter(page).at(loc)
     ))
 
   // Create links, excluding duplicate page numbers


### PR DESCRIPTION
Fixes the page backlinks of an entry in the glossary using the true page number instead of the page counter, this is only an issue if the page counter is ever reset.


Relevant piece of the documentation: https://typst.app/docs/reference/introspection/location/#definitions-page

EDIT: I checked the PR again, and saw that I forgot to add the spread operator - oops!