### PR TITLE
Simplify labels for autocomplete, make terms clickable

### DIFF
--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -431,7 +431,7 @@
     __add_entry(key, __normalize_entry(key, entry))
     // Create placeholder labels for autocompletion (if not already present)
     context if not __has_glossary_entry(key) [
-      #metadata("RF")#label(key)
+      #metadata(key)#label(key)
     ]
   }
 

--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -551,24 +551,24 @@
         ))
       }
     }
-
-  // Add non-empty groups to output
-  if current_entries.len() > 0 {
-    group = if group == none { "" } else { group }
-
-    // sort entries by case insensitivity if requested
-    let sorted_entries = current_entries
-      // 1. create array of tuples with (lower [if ignore-case], entry)
-      .map(e => { if ignore-case { (lower(e.short), e) } else { (e.short, e) } })
-      // 2. sort the tuples (by first element then second)
-      .sorted(key: t => t.first())
-      // 3. strip away the tuple's first element, leaving an array of entries
-      .map(t => t.last())
-
-    // add entries to this group's output map
-    output.insert(group, sorted_entries)
+  
+    // Add non-empty groups to output
+    if current_entries.len() > 0 {
+      group = if group == none { "" } else { group }
+  
+      // sort entries by case insensitivity if requested
+      let sorted_entries = current_entries
+        // 1. create array of tuples with (lower [if ignore-case], entry)
+        .map(e => { if ignore-case { (lower(e.short), e) } else { (e.short, e) } })
+        // 2. sort the tuples (by first element then second)
+        .sorted(key: t => t.first())
+        // 3. strip away the tuple's first element, leaving an array of entries
+        .map(t => t.last())
+  
+      // add entries to this group's output map
+      output.insert(group, sorted_entries)
+    }
   }
-}
 
   // Render the glossary using the theme
   let group_index = 0


### PR DESCRIPTION
To close #3 this PR
- with 16ceebdc70c97fb7f50cb406c3cc7192a44417cd
  - Always adds a label with the entry key for it to show up in the autocompletion list
    - either in the glossary (if it is visible and there is a corresponding entry)
    - or invisible during init-glossary as discussed in #3
  - Use a single label for all usages of the term in the text. This simplifies the back-referencing logic significantly and also avoids cluttering the auto-complete list
- with 76fb6b9ea7d8a1f751ab7b6c0140fe24fa796e12
  - Unifies the term usage tracking logic, which was done via counter and state in parallel. It now uses only the counter. Refractors the code with the two methods "mark_term_used" and "is_term_used".
- with 2b6debb7d1de1c7e4d591f2479c8c7d9523c64ae
  - Make the terms clickable links leading to the corresponding entry in the glossary (only if glossary is actually shown). I added a new option `term-links` to allow disabling these forward links. Also, if there are multiple glossaries and a term is listed more than once, links are disabled too since then there is no unique target.


![grafik](https://github.com/user-attachments/assets/6eb9ad81-2301-4255-867d-3525c54bdb2b)

Screenshot from typst.app