### PR TITLE
Draft: [Glossy] Typst 0.13 compatibility

### DIFF
--- a/glossy/README.md
+++ b/glossy/README.md
@@ -41,7 +41,7 @@ different goals:
 ### Import the package
 
 ```typst
-#import "@preview/glossy:0.6.0": *
+#import "@preview/glossy:0.7.0": *
 ```
 
 ### Defining Glossary Terms

--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -1,4 +1,4 @@
-#import "@preview/valkyrie:0.2.1" as z
+#import "@preview/valkyrie:0.2.2" as z
 
 #import "./schemas.typ": *
 #import "./themes.typ": *

--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -39,7 +39,7 @@
   if not "short" in entry {
     panic("Entry must contain a 'short' key")
   }
-  if type(entry.short) != "string" {
+  if type(entry.short) != str {
     panic("Entry 'short' must be a string")
   }
   if entry.short.trim() == "" {
@@ -347,7 +347,7 @@
 
   // Apply format-term() to get the term
   let formatted-term = format-term(mode, short-form, long-form)
-  if type(formatted-term) != "string" {
+  if type(formatted-term) != str {
     // This is because we still need to capitalize the term, and we cannot do
     // that with content, thus requiring a string here.
     // TODO: consider if we want to capitalize *before* this. First intuition is

--- a/glossy/src/schemas.typ
+++ b/glossy/src/schemas.typ
@@ -1,4 +1,4 @@
-#import "@preview/valkyrie:0.2.1" as z
+#import "@preview/valkyrie:0.2.2" as z
 
 #let dict-schema = z.either(
   z.string(),

--- a/glossy/tests/forward-links/test.typ
+++ b/glossy/tests/forward-links/test.typ
@@ -1,5 +1,5 @@
 #import "/lib.typ": *
-#import "@preview/glossarium:0.5.1": *
+#import "@preview/glossarium:0.5.3": *
 
 #set page(height: auto, width: 4.5in)
 #show link: set text(fill: red)

--- a/glossy/typst.toml
+++ b/glossy/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glossy"
-version = "0.6.0"
+version = "0.7.0"
 entrypoint = "lib.typ"
 authors = ["Stephen Waits <steve@waits.net>"]
 license = "MIT"


### PR DESCRIPTION
Ensure compatibility with soon to be released typst 0.13 

- Update dependencies
  - Waiting for https://github.com/typst-community/valkyrie/issues/52
  - Waiting for https://github.com/typst/packages/pull/1719
- Fix type to string comparison ([deprecated since 0.8](https://typst.app/docs/reference/foundations/type#compatibility) and removed with 0.13)