### PR TITLE
Add show-all flag to glossary() and test-case

### DIFF
--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -574,6 +574,7 @@
   sort: true,
   ignore-case: false,
   groups: (),
+  show-all: false,
 ) = context {
   // Type checking
   let checked-title = z.parse(title, z.content(), scope: ("title",))
@@ -584,7 +585,11 @@
   // Collect and organize entries by group
   let output = (:)
   let all_entries = __gloss_entries.final()
-  let all_used = all_entries.keys().filter(key => __is_term_ever_used(key))
+  let all_used = if not show-all {
+    all_entries.keys().filter(key => __is_term_ever_used(key))
+  } else {
+    all_entries.keys()
+  }
 
   // Determine which groups to process
   let all_groups = all_entries

--- a/glossy/tests/show-all/test.typ
+++ b/glossy/tests/show-all/test.typ
@@ -1,0 +1,33 @@
+#import "/lib.typ": *
+
+#show: init-glossary.with((
+  one: "this is term one",
+  two: "term two also"
+))
+
+#set page(
+  margin: 1em,
+  width: 3.5in,
+  height: auto,
+)
+#set text(size: 10pt)
+
+In this document we don't reference our glossary items but expect them to be
+shown anyway.
+
+#glossary(show-all: true)
+
+#glossary(
+  theme: theme-chicago-index,
+  show-all: true
+)
+
+#glossary(
+  theme: theme-compact,
+  show-all: true
+)
+
+#glossary(
+  theme: theme-table,
+  show-all: true
+)


### PR DESCRIPTION
Made a quick edit to the glossary function to allow showing all entries regardless of if they've been used in the text (#42).

I've also added what may be quite a basic test-case that compiles successfully (on my install of typst 0.12.0 (737895d7))