### PR TITLE
docs: fix setting of custom theme in glossary function

### DIFF
--- a/glossy/README.md
+++ b/glossy/README.md
@@ -203,7 +203,7 @@ Display the glossary using the `glossary()` function:
 ```typst
 #glossary(
   title: "Web Development Glossary", // Optional: defaults to Glossary theme:
-  my-theme, // Optional: defaults to theme-academic
+  theme: my-theme, // Optional: defaults to theme-academic
   sort: true, // Optional: whether or not to sort the glossary
   ignore-case: false, // Optional: ignore case when sorting terms
   groups: ("Web")  // Optional: Filter to specific groups


### PR DESCRIPTION
I found a little bug in the readme which would prevent the document from compiling if copied and pasted directly.  
The `theme` key was missing for the dictionary for the glossary function.

I hope this meets your code quality standards. (: