### PR TITLE
Improve first usage control

### DIFF
--- a/glossy/README.md
+++ b/glossy/README.md
@@ -203,7 +203,7 @@ Display the glossary using the `glossary()` function:
 ```typst
 #glossary(
   title: "Web Development Glossary", // Optional: defaults to Glossary theme:
-  my-theme, // Optional: defaults to theme-academic
+  theme: my-theme, // Optional: defaults to theme-academic
   sort: true, // Optional: whether or not to sort the glossary
   ignore-case: false, // Optional: ignore case when sorting terms
   groups: ("Web")  // Optional: Filter to specific groups

--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -208,7 +208,7 @@
 //   content: The fully formatted term, including optional article, capitalization,
 //            usage tracking metadata, and the chosen form (short, long, or both).
 //
-#let __gls(key, modifiers: array, format-term: function, show-term: function, term-links: true) = {
+#let __gls(key, modifiers: array, format-term: function, show-term: function, term-links: true, supplement: none) = {
   // ---------------------------------------------------------------------------
   // Check for illegal modifier combinations
   // ---------------------------------------------------------------------------
@@ -355,6 +355,9 @@
 
   // Get the article, then capitalize either the article or term (if requested)
   let (article, term) = capitalize_term(get_article(mode), formatted-term)
+  if type(supplement) == content {
+    term = supplement
+  }
 
   // ---------------------------------------------------------------------------
   // Construct and return the final output
@@ -521,7 +524,7 @@
     // Now see if this is an actual glossary term key
     if __has_entry(key) {
       // Found in dictionary, render via __gls()
-      __gls(key, modifiers: modifiers.map(lower), format-term: format-term, show-term: show-term, term-links: term-links)
+      __gls(key, modifiers: modifiers.map(lower), format-term: format-term, show-term: show-term, term-links: term-links, supplement: r.supplement)
     } else {
       // Not one of ours, so just pass it through
       r

--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -238,11 +238,9 @@
   // Manage term usage counting and determine if it's the first reference
   // ---------------------------------------------------------------------------
   let is_first_use = not __is_term_first_used(key, location: here())
-  let count-as-first-use = ("short" not in modifiers and "long" not in modifiers and "both" not in modifiers)
+  let count-as-first-use = ("short" not in modifiers and "long" not in modifiers and "nofirst" not in modifiers) or "first" in modifiers
   let wants_reference = ("noref" not in modifiers and "noindex" not in modifiers)
-  if wants_reference {
-    __mark_term_used(key, count-as-first-use)
-  }
+  __mark_term_used(key, count-as-first-use)
 
   // ---------------------------------------------------------------------------
   // Helper Functions
@@ -352,7 +350,7 @@
     // that with content, thus requiring a string here.
     // TODO: consider if we want to capitalize *before* this. First intuition is
     // "no".
-    panic("Your cutsom format-term() function must return a string.")
+    panic("Your custom format-term() function must return a string.")
   }
 
   // Get the article, then capitalize either the article or term (if requested)


### PR DESCRIPTION
This pull request addresses swaits-typst-packages/typst-collection#34, swaits-typst-packages/glossy#5 (partially) and swaits-typst-packages/glossy#6. I just saw that you already have an implementation of using the reference supplement (https://github.com/swaits/typst-collection/issues/34#issuecomment-2683517491), so please feel free to pick and choose from these commits.

In plain words this PR changes the following:

- The default behaviour for `@key:both` is now to act as a first use (if the reader has seen both long form and abbreviation, by default, they should not be shown again IMO)
- Whether `@key` is relevant for the first use counter can now be specified with `@key:first` or `@key:nofirst` and of course this can be combined with all other modifiers. `@key:short:first` for example will show the abbreviation and from then on `@key` will only expand to the short form too
- When specifying a supplement like `@key[Hello]` the text in the document is "Hello" instead of the short version of the specified key. The links to and from this element stay the same though.
- To fully address the use case in swaits-typst-packages/glossy#5 where some terms should never be expanded, I've added `firstuse` and `lateruse` fields to the entry dictionary. which default to `"both"` and `"short"` respectively. By specifying `firstuse: "short"` only the abbreviated version of the term would be shown even on first use, for this specific entry.

I am not sure, whether the last change is the correct design decision, because it is hard to imagine what `(firstuse: "short", lateruse: "both")` or `(firstuse: "long", lateruse: "both")` would be useful for.  Still, it feels like the use case in swaits-typst-packages/glossy#5 is advanced and so it is fine IMO to give maximum flexibility to power uses, while most people don't need to look at that. The one case, which I can imagine as being useful is `(firstuse: "long", lateruse: "long")` for when one wants the whole phrase written out each time with a reference to the glossary, where an even more complete description is given.

This PR does not cover the "reset" functionality that was asked for in swaits-typst-packages/glossy#5.