### PR TITLE
glossy: generate correct links to glossary entry

### DIFF
--- a/glossy/src/gloss.typ
+++ b/glossy/src/gloss.typ
@@ -408,15 +408,6 @@
       [#metadata("hidden term")#term-label]
     } else {
       // normal term display (ie not hidden)
-
-      // create the forward link, if watned
-      let linked-term = if term-links and __has_glossary_entry(key) {
-        link(label(key), term)
-      } else {
-        term
-      }
-
-      // and the final content
       [#article#show-term(linked-term)#metadata(term)#term-label]
       // |^^^^^|^^^^^^^^^             |^^^^^^^^      |^^^^^^^^^^^^
       // \_art.|                      |              |


### PR DESCRIPTION
The issue #48 comes from a bug in the way my changes in #46 were merged with the handling of the "hidden" modifier. Consider [lines 393 to 429](https://github.com/swaits/typst-collection/blob/b399080660c0566792cb3579ccf52ce7af9048a6/glossy/src/gloss.typ#L393C1-L429C6) of the current `gloss.typ` code 

```typst
let linked-term = if term-links and query(__entry_label(key)).len() > 0 {
  link(__entry_label(key), term)
} else {
  term
}
// Figure out our label (unless not wanted)
let term-label = if wants_reference {
  __term_label(key)
} else {
  []
}

// Create the output content
if mode == "hidden" {
  // just put the metadata+label out there
  [#metadata("hidden term")#term-label]
} else {
  // normal term display (ie not hidden)

  // create the forward link, if watned
  let linked-term = if term-links and __has_glossary_entry(key) {
    link(label(key), term)
  } else {
    term
  }

  // and the final content
  [#article#show-term(linked-term)#metadata(term)#term-label]
  // |^^^^^|^^^^^^^^^             |^^^^^^^^      |^^^^^^^^^^^^
  // \_art.|                      |              |
  //       \_ apply user formatting function to the term
  //                              |              |
  //                              \_ metadata lets us label (ie makes it "labelable")
  //                                             |
  //                                             \_ i.e. <__gloss:key>, etc.
  //                                                for backlink from glossary
}
``` 

Clearly, if `mode` is not "hidden", then the `linked-term` variable is overwritten to not link to `__entry_label(key)` but to `key` itself, which is a placeholder reference for the autocomplete mechanism and indeed lives on the first page of the document.

The fix is to remove the second definition of `linked-term`, which this PR does.